### PR TITLE
Fix download of local files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,4 @@ group :development do
 end
 
 gem 'carrierwave', '>= 0.5.8'
-gem 'crypt19', '1.2.1'
+gem 'crypt19-rb', '1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     carrierwave (0.6.2)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
-    crypt19 (1.2.1)
+    crypt19-rb (1.2.1)
     git (1.2.5)
     i18n (0.6.1)
     jeweler (1.6.4)
@@ -29,7 +29,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   carrierwave (>= 0.5.8)
-  crypt19 (= 1.2.1)
+  crypt19-rb (= 1.2.1)
   jeweler (~> 1.6.4)
   rcov
   shoulda

--- a/carrierwave_securefile.gemspec
+++ b/carrierwave_securefile.gemspec
@@ -46,14 +46,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<carrierwave>, [">= 0.5.8"])
-      s.add_runtime_dependency(%q<crypt19>, ["= 1.2.1"])
+      s.add_runtime_dependency(%q<crypt19-rb>, ["= 1.2.1"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
       s.add_dependency(%q<carrierwave>, [">= 0.5.8"])
-      s.add_dependency(%q<crypt19>, ["= 1.2.1"])
+      s.add_dependency(%q<crypt19-rb>, ["= 1.2.1"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<carrierwave>, [">= 0.5.8"])
-    s.add_dependency(%q<crypt19>, ["= 1.2.1"])
+    s.add_dependency(%q<crypt19-rb>, ["= 1.2.1"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])

--- a/lib/carrierwave/securefile/downloader.rb
+++ b/lib/carrierwave/securefile/downloader.rb
@@ -1,47 +1,35 @@
 module CarrierWave
-	module SecureFile
-		module Downloader
-
-			class << self
-
-				def call(uploader_model, activerecord_record, file_field)
-					Rails.logger.debug "Downloading using #{CarrierWave::SecureFile.cryptable}..."
-					file = nil
-					downloader = uploader_model.new
-					uploaded_file = activerecord_record
-					filename = eval("uploaded_file.#{file_field.to_s}").to_s
-					begin
-						downloader.download!(filename)
-						file = downloader.file.path.to_s
-					rescue Exception => e
-						Rails.logger.debug "Unable to download file: #{e}"
-					end
-					
-					if File.exists? file
-						ext_file = file + ".x1"
-						File.rename(file,ext_file)
-						configuration = CarrierWave::SecureFile.configuration
-						if configuration.encryption_type.downcase.to_sym == :aes
-							aes_key = configuration.aes_key
-							if activerecord_record.respond_to? :aes_key
-								aes_key = activerecord_record.aes_key
-							end
-							bf = CarrierWave::SecureFile::AESFileDecrypt.new(aes_key, configuration.aes_iv)
-							bf.do ext_file, file
-						else
-							bf = CarrierWave::SecureFile.cryptable.new(configuration.cypher)
-							bf.decrypt_file ext_file, file
-						end
-						File.unlink ext_file
-						return { :file => file, :content_type => uploaded_file.content_type }
-          else 
-            # return nil if no file was found
+  module SecureFile
+    module Downloader
+      class << self
+        def call(uploader_instance)
+          Rails.logger.debug "Downloading using #{CarrierWave::SecureFile.cryptable}..."
+          uploader_instance = uploader_instance.clone
+          begin
+            uploader_instance.cache_stored_file!
+            @file = uploader_instance.to_s
+          rescue Exception => e
+            Rails.logger.debug "Unable to download/copy file: #{e}"
+          end
+          unless File.exists? @file.to_s
             Rails.logger.debug "Unable to find the target file."
-            nil
-        	end
-				end		
-
-			end
-		end
-	end
+            return nil
+          end
+          ext_file = @file + ".x1"
+          File.rename @file, ext_file
+          configuration = CarrierWave::SecureFile.configuration
+          if configuration.encryption_type.downcase.to_sym == :aes
+            aes_key = uploader_instance.model.aes_key rescue configuration.aes_key
+            bf      = CarrierWave::SecureFile::AESFileDecrypt.new(aes_key, configuration.aes_iv)
+            bf.do ext_file, @file
+          else
+            bf = CarrierWave::SecureFile.cryptable.new(configuration.cypher)
+            bf.decrypt_file ext_file, @file
+          end
+          File.unlink ext_file
+          { :file => @file, :content_type => uploader_instance.file.content_type }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Download of local files was broken as `#download!` was explicitly called on the uploader. Use of `#cache_stored_file!` should work for any backend.
Signature of `CarrierWave::SecureFile::Downloader.call()` has changed. It now accepts only one argument: an uploader instance.
