### PR TITLE
Update crypt19 to use new rubygems gemfile name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,4 @@ group :development do
 end
 
 gem 'carrierwave', '>= 0.5.8'
-gem 'crypt19', '1.2.1'
+gem 'crypt19-rb', '~> 1.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,4 @@ group :development do
 end
 
 gem 'carrierwave', '>= 0.5.8'
-gem 'crypt19-rb', '~> 1.2.1'
+gem 'crypt19-rb', '=1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     carrierwave (0.6.2)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
-    crypt19 (1.2.1)
+    crypt19-rb (1.2.1)
     git (1.2.5)
     i18n (0.6.1)
     jeweler (1.6.4)
@@ -29,7 +29,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   carrierwave (>= 0.5.8)
-  crypt19 (= 1.2.1)
+  crypt19-rb (= 1.2.1)
   jeweler (~> 1.6.4)
   rcov
   shoulda

--- a/carrierwave_securefile.gemspec
+++ b/carrierwave_securefile.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
       s.add_dependency(%q<carrierwave>, [">= 0.5.8"])
-      s.add_dependency(%q<crypt19>, ["= 1.2.1"])
+      s.add_dependency(%q<crypt19-rb>, ["= 1.2.1"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<carrierwave>, [">= 0.5.8"])
-    s.add_dependency(%q<crypt19>, ["= 1.2.1"])
+    s.add_dependency(%q<crypt19-rb>, ["= 1.2.1"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])

--- a/carrierwave_securefile.gemspec
+++ b/carrierwave_securefile.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<carrierwave>, [">= 0.5.8"])
-      s.add_runtime_dependency(%q<crypt19>, ["= 1.2.1"])
+      s.add_runtime_dependency(%q<crypt19-rb>, ["= 1.2.1"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])


### PR DESCRIPTION
Hi, crypt19 somehow was deleted from rubygems at the end of Feb. It came back but under a different name. I just updated this to use the new name. 
